### PR TITLE
fix(git): add trailing slash to `.vscode` entry in `gitignore` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-.vscode
+.vscode/


### PR DESCRIPTION
Add a trailing slash to the `.vscode` entry in the [`gitignore` file](.gitignore) to ensure the directory is properly ignored.