### PR TITLE
refactor(lefthook): update Lefthook configuration to use jobs syntax

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -1,6 +1,7 @@
 extends: "@commitlint/config-conventional"
 
 scopes: &scopes
+  - editorconfig
   - git
   - lefthook
   - templates

--- a/.editorconfig
+++ b/.editorconfig
@@ -12,4 +12,4 @@ trim_trailing_whitespace = true
 trim_trailing_whitespace = false
 
 [UNLICENSE.txt]
-indent_size = unset
+indent_size = 0

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -1,19 +1,22 @@
 pre-commit:
   piped: true
-  commands:
-    lint-files-with-editorconfig:
-      priority: 1
+  jobs:
+    - name: Lint files with EditorConfig
       run: npx --yes editorconfig-checker {staged_files}
-      tags: lint editorconfig
-
-    lint-markdown-files:
-      priority: 2
+      tags:
+        - lint
+        - editorconfig
+    - name: Lint Markdown files
       glob: "*.md"
       run: npx --yes markdownlint-cli {staged_files}
-      tags: lint markdownlint
+      tags:
+        - lint
+        - markdownlint
 
 commit-msg:
-  commands:
-    lint-commit-message:
+  jobs:
+    - name: Lint commit message
       run: npx --yes commitlint --edit
-      tags: lint commitlint
+      tags:
+        - lint
+        - commitlint


### PR DESCRIPTION
This pull request updates the [Lefthook configuration file](.lefthook.yml) to use the [jobs syntax](https://lefthook.dev/configuration/jobs.html) instead of commands. It also adds the `editorconfig` scope to the [`commitlint` settings](.commitlintrc.yml) and adjusts the [EditorConfig file](.editorconfig) to set `indent_size` to 0 instead of unset for the `UNLICENSE.txt` file.