### PR TITLE
feat(ci): use locally installed linting tools

### DIFF
--- a/.github/workflows/commit-messages-linting.yml
+++ b/.github/workflows/commit-messages-linting.yml
@@ -26,8 +26,9 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: lts/*
+      - name: Install the linting tool
+        run: npm install --global @commitlint/cli @commitlint/config-conventional
       - name: Lint commit messages
         run: |
-          npm install --global @commitlint/config-conventional
           echo "::notice title=Last commit message::$(git show -s --format=%s)"
-          npx commitlint${{ inputs.from && format(' --from {0}', inputs.from) }} --to ${{ inputs.to }}
+          commitlint${{ inputs.from && format(' --from {0}', inputs.from) }} --to ${{ inputs.to }}

--- a/.github/workflows/files-changed-linting.yml
+++ b/.github/workflows/files-changed-linting.yml
@@ -46,6 +46,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: 'stable'
+          cache: false
       - name: Install the linting tool
         if: steps.files_changed.outputs.files_count > 0
         run: go install github.com/editorconfig-checker/editorconfig-checker/v3/cmd/editorconfig-checker@latest

--- a/.github/workflows/files-changed-linting.yml
+++ b/.github/workflows/files-changed-linting.yml
@@ -44,6 +44,8 @@ jobs:
       - name: Setup a Go environment
         if: steps.files_changed.outputs.files_count > 0
         uses: actions/setup-go@v6
+        with:
+          go-version: 'stable'
       - name: Install the linting tool
         if: steps.files_changed.outputs.files_count > 0
         run: go install github.com/editorconfig-checker/editorconfig-checker/v3/cmd/editorconfig-checker@latest

--- a/.github/workflows/files-changed-linting.yml
+++ b/.github/workflows/files-changed-linting.yml
@@ -41,14 +41,15 @@ jobs:
           echo "Markdown: $markdown_files_count"
           echo "::endgroup::"
           eval $files_changed
-      - name: Setup a Node.js environment
+      - name: Setup a Go environment
         if: steps.files_changed.outputs.files_count > 0
-        uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
+        uses: actions/setup-go@v6
+      - name: Install the linting tool
+        if: steps.files_changed.outputs.files_count > 0
+        run: go install github.com/editorconfig-checker/editorconfig-checker/v3/cmd/editorconfig-checker@latest
       - name: Lint the files against EditorConfig
         if: steps.files_changed.outputs.files_count > 0
-        run: npx editorconfig-checker ${{ steps.files_changed.outputs.files }}
+        run: editorconfig-checker ${{ steps.files_changed.outputs.files }}
     outputs:
       markdown_files: ${{ steps.files_changed.outputs.markdown_files }}
       markdown_files_count: ${{ steps.files_changed.outputs.markdown_files_count }}
@@ -65,5 +66,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: lts/*
+      - name: Install the linting tool
+        run: npm install --global markdownlint-cli
       - name: Lint Markdown files
-        run: npx markdownlint-cli ${{ needs.lint-files-against-editorconfig.outputs.markdown_files }}
+        run: markdownlint-cli ${{ needs.lint-files-against-editorconfig.outputs.markdown_files }}

--- a/.github/workflows/integration-validation.yml
+++ b/.github/workflows/integration-validation.yml
@@ -12,7 +12,7 @@ jobs:
     with:
       to: ${{ github.sha }}
 
-  lint-files-against-editorconfig:
+  lint-files-changed:
     name: Lint
     needs: lint-commit-messages
     uses: ./.github/workflows/files-changed-linting.yml

--- a/.github/workflows/pull-request-title-linting.yml
+++ b/.github/workflows/pull-request-title-linting.yml
@@ -19,8 +19,9 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: lts/*
+      - name: Install the linting tool
+        run: npm install --global @commitlint/cli @commitlint/config-conventional
       - name: Lint the pull request title
         run: |
-          npm install --global @commitlint/config-conventional
           echo "::notice title=Pull request title::${{ inputs.pr_title }}"
-          echo "${{ inputs.pr_title }}" | npx commitlint
+          echo "${{ inputs.pr_title }}" | commitlint

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -19,7 +19,7 @@ jobs:
       from: ${{ github.event.pull_request.base.sha }}
       to: ${{ github.event.pull_request.head.sha }}
 
-  lint-files-against-editorconfig:
+  lint-files-changed:
     name: Lint
     needs:
       - lint-pull-request-title

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -7,13 +7,14 @@ pre-commit:
       run: editorconfig-checker {staged_files}
       tags:
         - lint
-        - editorconfig
+        - files
     - name: Lint Markdown files
       glob: "*.md"
       run: markdownlint-cli {staged_files}
       tags:
         - lint
-        - markdownlint
+        - files
+        - markdown
 
 commit-msg:
   jobs:
@@ -21,4 +22,4 @@ commit-msg:
       run: commitlint --edit
       tags:
         - lint
-        - commitlint
+        - commit

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -4,13 +4,13 @@ pre-commit:
   piped: true
   jobs:
     - name: Lint the files against EditorConfig
-      run: npx --yes editorconfig-checker {staged_files}
+      run: editorconfig-checker {staged_files}
       tags:
         - lint
         - editorconfig
     - name: Lint Markdown files
       glob: "*.md"
-      run: npx --yes markdownlint-cli {staged_files}
+      run: markdownlint-cli {staged_files}
       tags:
         - lint
         - markdownlint
@@ -18,7 +18,7 @@ pre-commit:
 commit-msg:
   jobs:
     - name: Lint the commit message
-      run: npx --yes commitlint --edit
+      run: commitlint --edit
       tags:
         - lint
         - commitlint


### PR DESCRIPTION
This pull request updates the [GitHub Actions workflows](https://github.com/marlondecol/sample-project/tree/b5e8947c5df05b33c57e6b4bc4d4c101f1c1e952/.github/workflows) so that all linting tools are installed on the runner before being used, rather than being executed directly via the `npx` command. The [Lefthook jobs](https://github.com/marlondecol/sample-project/blob/b5e8947c5df05b33c57e6b4bc4d4c101f1c1e952/.lefthook.yml) now also expect the tools to be already installed locally before being used.

Other changes include fixes to the names of some GitHub Actions jobs and refinements to the tags of the Lefthook jobs.