### PR TITLE
fix(ci): correct `markdownlint-cli` command name to `markdownlint`

### DIFF
--- a/.github/workflows/files-changed-linting.yml
+++ b/.github/workflows/files-changed-linting.yml
@@ -72,4 +72,4 @@ jobs:
       - name: Install the linting tool
         run: npm install --global markdownlint-cli
       - name: Lint Markdown files
-        run: markdownlint-cli ${{ needs.lint-files-against-editorconfig.outputs.markdown_files }}
+        run: markdownlint ${{ needs.lint-files-against-editorconfig.outputs.markdown_files }}

--- a/.github/workflows/pull-request-title-linting.yml
+++ b/.github/workflows/pull-request-title-linting.yml
@@ -23,5 +23,5 @@ jobs:
         run: npm install --global @commitlint/cli @commitlint/config-conventional
       - name: Lint the pull request title
         run: |
-          echo "::notice title=Pull request title::${{ inputs.pr_title }}"
-          echo "${{ inputs.pr_title }}" | commitlint
+          echo '::notice title=Pull request title::${{ inputs.pr_title }}'
+          echo '${{ inputs.pr_title }}' | commitlint

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -10,7 +10,7 @@ pre-commit:
         - files
     - name: Lint Markdown files
       glob: "*.md"
-      run: markdownlint-cli {staged_files}
+      run: markdownlint {staged_files}
       tags:
         - lint
         - files


### PR DESCRIPTION
This pull request just corrects the command name from [`markdownlint-cli`](https://github.com/igorshubovych/markdownlint-cli) to `markdownlint` in some [GitHub Actions workflows](https://github.com/marlondecol/sample-project/tree/3fad311729c7a8d87b35d82d28afa770b90381a6/.github/workflows) and the corresponding [Lefthook job](https://github.com/marlondecol/sample-project/blob/3fad311729c7a8d87b35d82d28afa770b90381a6/.lefthook.yml).